### PR TITLE
Add MNIST synthetic dataset workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ Create a `images_shape.txt` file that stored with slide name, width and height o
 python get_image_shape.py
 ```
 
+### Synthetic MNIST dataset for experimentation
+
+To quickly validate the Bayes-MIL models without preparing whole-slide images,
+generate a toy dataset derived from MNIST:
+
+```bash
+python processing_scripts/create_mnist_synthetic_dataset.py \
+    --output-dir /path/to/mnist_mil_dataset
+```
+
+The command writes the expected `h5_files/`, metadata CSV files, and cross-validation
+splits. Refer to [docs/mnist_synthetic_dataset.md](docs/mnist_synthetic_dataset.md)
+for additional options and example training commands.
+
 ## Training
 1. Modify the format of the input data.
 

--- a/datasets/dataset_generic.py
+++ b/datasets/dataset_generic.py
@@ -323,7 +323,19 @@ class Generic_MIL_Dataset(Generic_WSI_Classification_Dataset):
 		self.data_dir = data_dir
 		self.use_h5 = False
 
-		shape_file = 'images_shape.txt'
+		shape_candidates = []
+		if isinstance(self.data_dir, str):
+			shape_candidates.append(os.path.join(self.data_dir, 'images_shape.txt'))
+		elif isinstance(self.data_dir, dict):
+			shape_candidates.extend(
+				[os.path.join(path, 'images_shape.txt') for path in self.data_dir.values() if isinstance(path, str)]
+			)
+		shape_candidates.append('images_shape.txt')
+
+		shape_file = next((path for path in shape_candidates if path and os.path.isfile(path)), None)
+		if shape_file is None:
+			raise FileNotFoundError('Unable to locate images_shape.txt. Checked: {}'.format(shape_candidates))
+
 		self.shape_dict = self.read_shapes(shape_file)
 
 	def load_from_h5(self, toggle):

--- a/docs/if_name_main.md
+++ b/docs/if_name_main.md
@@ -1,0 +1,18 @@
+# Understanding `if __name__ == "__main__":`
+
+In Python, every module has a built-in variable named `__name__`. When a file is executed directly (for example with `python my_script.py`), Python sets `__name__` to the string `"__main__"`. When the same file is imported as a module from another script, `__name__` instead takes the module's import name.
+
+Wrapping code in
+
+```python
+if __name__ == "__main__":
+    ...
+```
+
+ensures that the indented block only runs when the file is executed directly. This is commonly used to:
+
+- Provide a command-line entry point while keeping reusable functions/classes importable without side effects.
+- Run quick tests or demonstrations when the script is invoked alone, but avoid running them when the module is imported elsewhere.
+- Protect code that should not execute during module import (for example, costly training loops or dataset downloads).
+
+In the context of this repository, you might place training or evaluation logic inside this guard so that the module can be imported by other scripts (e.g., for experimentation or unit testing) without immediately launching a full experiment.

--- a/docs/mnist_synthetic_dataset.md
+++ b/docs/mnist_synthetic_dataset.md
@@ -1,0 +1,57 @@
+# Synthetic MNIST MIL dataset
+
+This guide explains how to generate a toy dataset based on MNIST digits that
+follows the file layout expected by Bayes-MIL. The dataset is convenient for
+running fast experiments without relying on whole-slide images.
+
+## 1. Create the dataset
+
+Run the helper script and provide the output directory that will host the
+artifacts. The script downloads MNIST through `torchvision` on first use.
+
+```bash
+python processing_scripts/create_mnist_synthetic_dataset.py \
+    --output-dir /path/to/mnist_mil_dataset \
+    --num-slides 200 --k-folds 5
+```
+
+Key options:
+
+- `--num-slides`: how many synthetic “slides” (bags) to create.
+- `--min-patches` / `--max-patches`: range for the number of MNIST digits per slide.
+- `--slides-per-case`: how many slides share the same case identifier.
+- `--k-folds`: number of cross-validation folds saved under `splits/<task>/`.
+
+The directory will contain:
+
+- `h5_files/slide_xxxx.h5`: flattened MNIST pixels and 2-D coordinates for each bag.
+- `mnist_binary.csv`: metadata for the binary task (`negative` vs `positive`).
+- `mnist_ternary.csv`: metadata for the ternary task (`low_digit`, `mid_digit`, `high_digit`).
+- `images_shape.txt`: synthetic canvas sizes used when reconstructing spatial maps.
+- `splits/mnist_binary/` and `splits/mnist_ternary/`: cross-validation CSV files.
+
+## 2. Launch training
+
+Point `main.py` to the generated directory with the new `--task` options. Below
+is an example for the binary classification task using Bayes-MIL-Vis.
+
+```bash
+python main.py \
+    --data_root_dir /path/to/mnist_mil_dataset \
+    --task mnist_binary \
+    --model_type bmil-vis \
+    --exp_code mnist_binary_example \
+    --k 5 --max_epochs 20 --lr 5e-4
+```
+
+Swap `--task` to `mnist_ternary` to evaluate the three-class task. The script
+reads the splits generated earlier (unless `--split_dir` overrides the path) and
+loads features from `h5_files/`.
+
+## 3. Troubleshooting
+
+- Ensure that `torchvision` is installed in the active environment so the script
+  can download MNIST.
+- When re-generating the dataset in the same directory, old files are overwritten.
+- If you wish to experiment with custom label definitions, modify the helper
+  script before generating the dataset.


### PR DESCRIPTION
## Summary
- add a helper script that builds MNIST-based MIL bags, metadata CSVs, and stratified CV splits
- document the synthetic dataset workflow and surface it from the main README
- allow Generic_MIL_Dataset to resolve images_shape.txt relative to the data root and wire new mnist_* tasks into main.py

## Testing
- python -m compileall processing_scripts/create_mnist_synthetic_dataset.py main.py
- python -m compileall datasets/dataset_generic.py

------
https://chatgpt.com/codex/tasks/task_e_68e3854d1c188324aa08a597d68c8309