### PR TITLE
Add datasets package initializer

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -1,0 +1,1 @@
+# Dataset package initializer


### PR DESCRIPTION
## Summary
- add an ``__init__`` module so ``datasets`` is importable when running the training entrypoint

## Testing
- python - <<'PY'
import datasets.dataset_generic
print('import ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e3d3f85cd08324876a87b8be613662