### PR TITLE
Adapt BMIL input layers to dataset feature size

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -1,0 +1,1 @@
+# Dataset package initializer

--- a/models/model_bmil.py
+++ b/models/model_bmil.py
@@ -169,11 +169,14 @@ class GaussianSmoothing(nn.Module):
         return self.conv(input, weight=self.weight, groups=self.groups)
 
 class probabilistic_MIL_Bayes_vis(nn.Module):
-    def __init__(self, gate = True, size_arg = "small", dropout = False, n_classes=2, top_k=1):
+    def __init__(self, gate = True, size_arg = "small", dropout = False, n_classes=2, top_k=1, input_dim=None):
         super(probabilistic_MIL_Bayes_vis, self).__init__()
         self.size_dict = {"small": [1024, 512, 256], "big": [1024, 512, 384]}
-        size = self.size_dict[size_arg]
-        fc = [nn.Linear(size[0], size[1]), nn.ReLU()]
+        size = list(self.size_dict[size_arg])
+        if input_dim is not None:
+            size[0] = input_dim
+        self.input_dim = size[0]
+        fc = [nn.Linear(self.input_dim, size[1]), nn.ReLU()]
         if dropout:
             fc.append(nn.Dropout(0.25))
         if gate:
@@ -233,11 +236,14 @@ class probabilistic_MIL_Bayes_vis(nn.Module):
         return top_instance, Y_prob, Y_hat, y_probs, A
 
 class probabilistic_MIL_Bayes_enc(nn.Module):
-    def __init__(self, gate = True, size_arg = "small", dropout = False, n_classes=2, top_k=1):
+    def __init__(self, gate = True, size_arg = "small", dropout = False, n_classes=2, top_k=1, input_dim=None):
         super(probabilistic_MIL_Bayes_enc, self).__init__()
         self.size_dict = {"small": [1024, 512, 256], "big": [1024, 512, 384]}
-        size = self.size_dict[size_arg]
-        first_transform = nn.Linear(size[0], size[1])
+        size = list(self.size_dict[size_arg])
+        if input_dim is not None:
+            size[0] = input_dim
+        self.input_dim = size[0]
+        first_transform = nn.Linear(self.input_dim, size[1])
         fc1 = [first_transform, nn.ReLU()]
 
         if dropout:
@@ -324,15 +330,18 @@ class probabilistic_MIL_Bayes_enc(nn.Module):
 PATCH_SIZE = 256
 
 class probabilistic_MIL_Bayes_spvis(nn.Module):
-    def __init__(self, gate=True, size_arg="small", dropout=False, n_classes=2, top_k=1):
+    def __init__(self, gate=True, size_arg="small", dropout=False, n_classes=2, top_k=1, input_dim=None):
         super(probabilistic_MIL_Bayes_spvis, self).__init__()
 
         # self.size_dict = {"small": [1024, 512, 256], "big": [1024, 512, 384]}
         self.size_dict = {"small": [1024, 512, 256], "big": [1024, 512, 384]}
-        size = self.size_dict[size_arg]
+        size = list(self.size_dict[size_arg])
+        if input_dim is not None:
+            size[0] = input_dim
+        self.input_dim = size[0]
 
         ard_init = -4.
-        self.linear1 = nn.Linear(size[0], size[1])
+        self.linear1 = nn.Linear(self.input_dim, size[1])
         self.linear2a = LinearVDO(size[1], size[2], ard_init=ard_init)
         self.linear2b = LinearVDO(size[1], size[2], ard_init=ard_init)
         self.linear3 = LinearVDO(size[2], 2, ard_init=ard_init)

--- a/models/model_bmil_subtyping.py
+++ b/models/model_bmil_subtyping.py
@@ -169,11 +169,14 @@ class GaussianSmoothing(nn.Module):
         return self.conv(input, weight=self.weight, groups=self.groups)
 
 class probabilistic_MIL_Bayes_vis(nn.Module):
-    def __init__(self, gate = True, size_arg = "small", dropout = False, n_classes=2, top_k=1):
+    def __init__(self, gate = True, size_arg = "small", dropout = False, n_classes=2, top_k=1, input_dim=None):
         super(probabilistic_MIL_Bayes_vis, self).__init__()
         self.size_dict = {"small": [1024, 512, 256], "big": [1024, 512, 384]}
-        size = self.size_dict[size_arg]
-        fc = [nn.Linear(size[0], size[1]), nn.ReLU()]
+        size = list(self.size_dict[size_arg])
+        if input_dim is not None:
+            size[0] = input_dim
+        self.input_dim = size[0]
+        fc = [nn.Linear(self.input_dim, size[1]), nn.ReLU()]
         if dropout:
             fc.append(nn.Dropout(0.25))
         if gate:
@@ -233,11 +236,14 @@ class probabilistic_MIL_Bayes_vis(nn.Module):
         return top_instance, Y_prob, Y_hat, y_probs, A
 
 class probabilistic_MIL_Bayes_enc(nn.Module):
-    def __init__(self, gate = True, size_arg = "small", dropout = False, n_classes=2, top_k=1):
+    def __init__(self, gate = True, size_arg = "small", dropout = False, n_classes=2, top_k=1, input_dim=None):
         super(probabilistic_MIL_Bayes_enc, self).__init__()
         self.size_dict = {"small": [1024, 512, 256], "big": [1024, 512, 384]}
-        size = self.size_dict[size_arg]
-        first_transform = nn.Linear(size[0], size[1])
+        size = list(self.size_dict[size_arg])
+        if input_dim is not None:
+            size[0] = input_dim
+        self.input_dim = size[0]
+        first_transform = nn.Linear(self.input_dim, size[1])
         fc1 = [first_transform, nn.ReLU()]
 
         if dropout:
@@ -324,15 +330,18 @@ class probabilistic_MIL_Bayes_enc(nn.Module):
 PATCH_SIZE = 256
 
 class probabilistic_MIL_Bayes_spvis(nn.Module):
-    def __init__(self, gate=True, size_arg="small", dropout=False, n_classes=2, top_k=1):
+    def __init__(self, gate=True, size_arg="small", dropout=False, n_classes=2, top_k=1, input_dim=None):
         super(probabilistic_MIL_Bayes_spvis, self).__init__()
 
         # self.size_dict = {"small": [1024, 512, 256], "big": [1024, 512, 384]}
         self.size_dict = {"small": [1024, 512, 256], "big": [1024, 512, 384]}
-        size = self.size_dict[size_arg]
+        size = list(self.size_dict[size_arg])
+        if input_dim is not None:
+            size[0] = input_dim
+        self.input_dim = size[0]
 
         ard_init = -4.
-        self.linear1 = nn.Linear(size[0], size[1])
+        self.linear1 = nn.Linear(self.input_dim, size[1])
         self.linear2a = LinearVDO(size[1], size[2], ard_init=ard_init)
         self.linear2b = LinearVDO(size[1], size[2], ard_init=ard_init)
         self.linear3 = LinearVDO(size[2], 2, ard_init=ard_init)

--- a/utils/core_utils.py
+++ b/utils/core_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 from utils.utils import *
 import os
+import h5py
 from datasets.dataset_generic import save_splits
 
 from models.model_bmil import bMIL_model_dict
@@ -14,6 +15,51 @@ from sklearn.metrics import auc as calc_auc
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 N_SAMPLES = 16
+
+
+def _infer_bag_feature_dim(split):
+    cached = getattr(split, '_cached_feature_dim', None)
+    if cached is not None:
+        return cached
+
+    slide_data = getattr(split, 'slide_data', None)
+    data_dir = getattr(split, 'data_dir', None)
+    if slide_data is None or data_dir is None or len(slide_data) == 0:
+        return None
+
+    try:
+        slide_row = slide_data.iloc[0]
+        slide_id = slide_row['slide_id']
+    except (AttributeError, KeyError, IndexError):
+        return None
+
+    if isinstance(data_dir, dict):
+        source = slide_row.get('source')
+        if source is None:
+            return None
+        data_dir = data_dir.get(source)
+        if data_dir is None:
+            return None
+
+    h5_path = os.path.join(data_dir, 'h5_files', f'{slide_id}.h5')
+    if not os.path.isfile(h5_path):
+        return None
+
+    try:
+        with h5py.File(h5_path, 'r') as handle:
+            features = handle['features']
+            shape = features.shape
+    except (OSError, KeyError):
+        return None
+
+    feature_dim = None
+    if len(shape) == 1:
+        feature_dim = int(shape[0])
+    elif len(shape) >= 2:
+        feature_dim = int(shape[-1])
+
+    setattr(split, '_cached_feature_dim', feature_dim)
+    return feature_dim
 
 import torch.nn as nn
 class ECELoss(nn.Module):
@@ -158,6 +204,9 @@ def train(datasets, cur, args):
 
     print('\nInit Model...', end=' ')
     model_dict = {"dropout": args.drop_out, 'n_classes': args.n_classes}
+    feature_dim = _infer_bag_feature_dim(train_split)
+    if feature_dim is not None:
+        model_dict.update({'input_dim': feature_dim})
     if args.model_type == 'clam' and args.subtyping:
         model_dict.update({'subtyping': True})
     


### PR DESCRIPTION
## Summary
- allow the BMIL model constructors to accept an optional input feature dimension so they can match datasets that are not 1024-D
- infer the bag feature dimensionality from the training split's first HDF5 file and forward it when building BMIL models

## Testing
- python -m compileall models/model_bmil.py models/model_bmil_subtyping.py utils/core_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e3d3f85cd08324876a87b8be613662