### PR TITLE
Add checkpoint validation for MNIST heatmap export

### DIFF
--- a/docs/mnist_synthetic_dataset.md
+++ b/docs/mnist_synthetic_dataset.md
@@ -88,7 +88,11 @@ The script writes PNGs to
 `heatmap_summary.csv` with predicted labels. Use `--split val` or `--split train`
 to export other subsets, or `--split all` to process every slide contained in
 the descriptor CSV. Pass `--skip-existing` to avoid re-rendering PNGs that are
-already present.
+already present. When working with the ternary task, rerun the training and
+evaluation helpers with `--task mnist_ternary` so that the checkpoint contains a
+three-class classifier. The heatmap export utility now validates that the
+selected checkpoint matches the requested task and raises a clear error if the
+class counts differ.
 
 ## 3. Troubleshooting
 


### PR DESCRIPTION
## Summary
- validate the classifier class count in MNIST heatmap checkpoints before model initialisation and provide a clear error when it mismatches the requested task
- document the need to train and evaluate ternary experiments with `--task mnist_ternary` so the exported heatmaps use matching checkpoints

## Testing
- python -m compileall vis_utils/mnist_attention_heatmap.py

------
https://chatgpt.com/codex/tasks/task_e_68e4fef1fe248324acb1075be3edfaac