### PR TITLE
Add multi-task MNIST interpretability datasets

### DIFF
--- a/docs/mnist_synthetic_dataset.md
+++ b/docs/mnist_synthetic_dataset.md
@@ -25,11 +25,15 @@ Key options:
 The directory will contain:
 
 - `h5_files/slide_xxxx.h5`: flattened MNIST pixels and 2-D coordinates for each bag.
-- `mnist_binary.csv`: metadata for the binary task (`negative` vs `positive`).
-- `mnist_ternary.csv`: metadata for the ternary task (`low_digit`, `mid_digit`, `high_digit`).
+- `mnist_fourbags.csv`: labels for the digit-8/9 counting task.
+- `mnist_even_odd.csv`: labels for the even-versus-odd majority task.
+- `mnist_adjacent_pairs.csv`: labels for the adjacent-pair detection task.
+- `mnist_fourbags_plus.csv`: labels for the composite rule-based task.
+- `evidence/<task>/slide_xxxx.pt`: per-instance evidence and digit identities saved
+  for interpretability analyses.
 - `images_shape.txt`: synthetic canvas sizes used when reconstructing spatial maps.
-- `splits/mnist_binary/` and `splits/mnist_ternary/`: cross-validation CSV files.
-- The generator enforces that each binary and ternary label is represented (when the
+- `splits/<task>/`: cross-validation CSV files for every task.
+- The generator enforces that each class for every task is represented (when the
   requested number of slides allows for it), avoiding degenerate datasets lacking a class.
 
 ## 2. Run the Bayes-MIL pipeline step by step
@@ -43,14 +47,16 @@ the workflow explicit and modular.
 ```bash
 python examples/mnist_train.py \
     --dataset-root /path/to/mnist_mil_dataset \
-    --task mnist_binary \
+    --task mnist_fourbags \
     --exp-code mnist_demo \
     --k 5 --max-epochs 20 --lr 5e-4
 ```
 
 All flags map one-to-one to the arguments consumed by `main.py`, so you can add
 `--drop-out`, `--early-stopping`, or `--weighted-sample` as needed. The script
-writes checkpoints under `<results-dir>/<exp-code>_s<seed>/`.
+writes checkpoints under `<results-dir>/<exp-code>_s<seed>/`. Switch `--task` to
+`mnist_even_odd`, `mnist_adjacent_pairs`, or `mnist_fourbags_plus` to train on the
+other synthetic objectives without changing any other flags.
 
 ### 2.2 Evaluate
 
@@ -60,7 +66,7 @@ After training, evaluate the checkpoints with `eval.py` via:
 python examples/mnist_evaluate.py \
     --dataset-root /path/to/mnist_mil_dataset \
     --results-dir results \
-    --task mnist_binary \
+    --task mnist_fourbags \
     --exp-code mnist_demo \
     --k 5
 ```
@@ -78,7 +84,7 @@ the test set of one fold, run:
 python examples/mnist_save_heatmaps.py \
     --dataset-root /path/to/mnist_mil_dataset \
     --results-dir results \
-    --task mnist_binary \
+    --task mnist_fourbags \
     --exp-code mnist_demo \
     --fold 0 --split test
 ```
@@ -88,11 +94,10 @@ The script writes PNGs to
 `heatmap_summary.csv` with predicted labels. Use `--split val` or `--split train`
 to export other subsets, or `--split all` to process every slide contained in
 the descriptor CSV. Pass `--skip-existing` to avoid re-rendering PNGs that are
-already present. When working with the ternary task, rerun the training and
-evaluation helpers with `--task mnist_ternary` so that the checkpoint contains a
-three-class classifier. The heatmap export utility now validates that the
-selected checkpoint matches the requested task and raises a clear error if the
-class counts differ.
+already present. When switching between tasks, rerun the training and evaluation
+helpers with the matching `--task` flag so that the checkpoint and split
+metadata agree on the number of classes. The heatmap export utility validates
+this and raises a clear error if a mismatch is detected.
 
 ## 3. Troubleshooting
 
@@ -111,7 +116,7 @@ model and saves an attention overlay for one slide:
 python vis_utils/mnist_attention_heatmap.py \
     --dataset-root /path/to/mnist_mil_dataset \
     --checkpoint results/mnist_demo_s1/s_0_checkpoint.pt \
-    --task mnist_binary \
+    --task mnist_fourbags \
     --model-type bmil-vis \
     --slide-id slide_0000
 ```
@@ -124,7 +129,7 @@ switch to render an entire split directly from the utility:
 python vis_utils/mnist_attention_heatmap.py \
     --dataset-root /path/to/mnist_mil_dataset \
     --checkpoint results/mnist_demo_s1/s_0_checkpoint.pt \
-    --task mnist_binary \
+    --task mnist_fourbags \
     --model-type bmil-vis \
     --fold 0 --split test --all
 ```

--- a/eval.py
+++ b/eval.py
@@ -47,8 +47,10 @@ parser.add_argument(
     choices=[
         'task_1_tumor_vs_normal',
         'task_2_tumor_subtyping',
-        'mnist_binary',
-        'mnist_ternary',
+        'mnist_fourbags',
+        'mnist_even_odd',
+        'mnist_adjacent_pairs',
+        'mnist_fourbags_plus',
     ],
 )
 args = parser.parse_args()
@@ -61,7 +63,7 @@ args.models_dir = os.path.join(args.results_dir, str(args.models_exp_code))
 os.makedirs(args.save_dir, exist_ok=True)
 
 if args.splits_dir is None:
-    if args.task in ['mnist_binary', 'mnist_ternary']:
+    if args.task in ['mnist_fourbags', 'mnist_even_odd', 'mnist_adjacent_pairs', 'mnist_fourbags_plus']:
         if args.data_root_dir is None:
             raise ValueError('MNIST evaluation requires --data_root_dir pointing to the dataset root')
         args.splits_dir = os.path.join(args.data_root_dir, 'splits', args.task)
@@ -104,32 +106,62 @@ elif args.task == 'task_2_tumor_subtyping':
                             patient_strat= False,
                             ignore=[])
 
-elif args.task == 'mnist_binary':
+elif args.task == 'mnist_fourbags':
     if args.data_root_dir is None:
-        raise ValueError('mnist_binary requires --data_root_dir pointing to the generated dataset directory')
-    args.n_classes = 2
-    csv_path = os.path.join(args.data_root_dir, 'mnist_binary.csv')
+        raise ValueError('mnist_fourbags requires --data_root_dir pointing to the generated dataset directory')
+    args.n_classes = 4
+    csv_path = os.path.join(args.data_root_dir, 'mnist_fourbags.csv')
     dataset = Generic_MIL_Dataset(
         csv_path=csv_path,
         data_dir=os.path.join(args.data_root_dir, ''),
         shuffle=False,
         print_info=True,
-        label_dict={'negative': 0, 'positive': 1},
+        label_dict={'none': 0, 'mostly_eight': 1, 'mostly_nine': 2, 'both': 3},
         patient_strat=False,
         ignore=[],
     )
 
-elif args.task == 'mnist_ternary':
+elif args.task == 'mnist_even_odd':
     if args.data_root_dir is None:
-        raise ValueError('mnist_ternary requires --data_root_dir pointing to the generated dataset directory')
-    args.n_classes = 3
-    csv_path = os.path.join(args.data_root_dir, 'mnist_ternary.csv')
+        raise ValueError('mnist_even_odd requires --data_root_dir pointing to the generated dataset directory')
+    args.n_classes = 2
+    csv_path = os.path.join(args.data_root_dir, 'mnist_even_odd.csv')
     dataset = Generic_MIL_Dataset(
         csv_path=csv_path,
         data_dir=os.path.join(args.data_root_dir, ''),
         shuffle=False,
         print_info=True,
-        label_dict={'low_digit': 0, 'mid_digit': 1, 'high_digit': 2},
+        label_dict={'odd_majority': 0, 'even_majority': 1},
+        patient_strat=False,
+        ignore=[],
+    )
+
+elif args.task == 'mnist_adjacent_pairs':
+    if args.data_root_dir is None:
+        raise ValueError('mnist_adjacent_pairs requires --data_root_dir pointing to the generated dataset directory')
+    args.n_classes = 2
+    csv_path = os.path.join(args.data_root_dir, 'mnist_adjacent_pairs.csv')
+    dataset = Generic_MIL_Dataset(
+        csv_path=csv_path,
+        data_dir=os.path.join(args.data_root_dir, ''),
+        shuffle=False,
+        print_info=True,
+        label_dict={'no_adjacent_pairs': 0, 'has_adjacent_pairs': 1},
+        patient_strat=False,
+        ignore=[],
+    )
+
+elif args.task == 'mnist_fourbags_plus':
+    if args.data_root_dir is None:
+        raise ValueError('mnist_fourbags_plus requires --data_root_dir pointing to the generated dataset directory')
+    args.n_classes = 4
+    csv_path = os.path.join(args.data_root_dir, 'mnist_fourbags_plus.csv')
+    dataset = Generic_MIL_Dataset(
+        csv_path=csv_path,
+        data_dir=os.path.join(args.data_root_dir, ''),
+        shuffle=False,
+        print_info=True,
+        label_dict={'none': 0, 'three_five': 1, 'one_only': 2, 'one_and_seven': 3},
         patient_strat=False,
         ignore=[],
     )

--- a/examples/mnist_evaluate.py
+++ b/examples/mnist_evaluate.py
@@ -16,7 +16,16 @@ def parse_args() -> argparse.Namespace:
         description='Run eval.py on MNIST checkpoints produced by main.py.',
     )
     parser.add_argument('--dataset-root', type=Path, required=True)
-    parser.add_argument('--task', choices=('mnist_binary', 'mnist_ternary'), default='mnist_binary')
+    parser.add_argument(
+        '--task',
+        choices=(
+            'mnist_fourbags',
+            'mnist_even_odd',
+            'mnist_adjacent_pairs',
+            'mnist_fourbags_plus',
+        ),
+        default='mnist_fourbags',
+    )
     parser.add_argument('--exp-code', type=str, required=True, help='Experiment identifier used during training.')
     parser.add_argument('--results-dir', type=Path, default=REPO_ROOT / 'results')
     parser.add_argument('--seed', type=int, default=1, help='Matches the value forwarded to main.py.')

--- a/examples/mnist_save_heatmaps.py
+++ b/examples/mnist_save_heatmaps.py
@@ -25,7 +25,16 @@ def parse_args() -> argparse.Namespace:
         description='Save attention heatmaps for every slide in a MNIST split.',
     )
     parser.add_argument('--dataset-root', type=Path, required=True)
-    parser.add_argument('--task', choices=('mnist_binary', 'mnist_ternary'), default='mnist_binary')
+    parser.add_argument(
+        '--task',
+        choices=(
+            'mnist_fourbags',
+            'mnist_even_odd',
+            'mnist_adjacent_pairs',
+            'mnist_fourbags_plus',
+        ),
+        default='mnist_fourbags',
+    )
     parser.add_argument('--results-dir', type=Path, required=True)
     parser.add_argument('--exp-code', type=str, required=True, help='Experiment identifier used during training.')
     parser.add_argument('--seed', type=int, default=1)

--- a/examples/mnist_train.py
+++ b/examples/mnist_train.py
@@ -22,7 +22,16 @@ def parse_args() -> argparse.Namespace:
         description='Launch Bayes-MIL training on the synthetic MNIST dataset.',
     )
     parser.add_argument('--dataset-root', type=Path, required=True, help='Directory produced by create_mnist_synthetic_dataset.py.')
-    parser.add_argument('--task', choices=('mnist_binary', 'mnist_ternary'), default='mnist_binary')
+    parser.add_argument(
+        '--task',
+        choices=(
+            'mnist_fourbags',
+            'mnist_even_odd',
+            'mnist_adjacent_pairs',
+            'mnist_fourbags_plus',
+        ),
+        default='mnist_fourbags',
+    )
     parser.add_argument('--exp-code', type=str, default='mnist_demo', help='Experiment identifier forwarded to main.py.')
     parser.add_argument('--results-dir', type=Path, default=REPO_ROOT / 'results', help='Where checkpoints will be written.')
     parser.add_argument('--model-type', choices=['bmil-vis', 'bmil-enc', 'bmil-spvis'], default='bmil-vis')

--- a/main.py
+++ b/main.py
@@ -116,7 +116,18 @@ parser.add_argument('--model_type', type=str, choices=['clam_sb', 'clam_mb', 'mi
 parser.add_argument('--exp_code', type=str, help='experiment code for saving results')
 parser.add_argument('--weighted_sample', action='store_true', default=False, help='enable weighted sampling')
 parser.add_argument('--model_size', type=str, choices=['small', 'big'], default='small', help='size of model, does not affect mil')
-parser.add_argument('--task', type=str, choices=['task_1_tumor_vs_normal',  'task_2_tumor_subtyping', 'mnist_binary', 'mnist_ternary'])
+parser.add_argument(
+    '--task',
+    type=str,
+    choices=[
+        'task_1_tumor_vs_normal',
+        'task_2_tumor_subtyping',
+        'mnist_fourbags',
+        'mnist_even_odd',
+        'mnist_adjacent_pairs',
+        'mnist_fourbags_plus',
+    ],
+)
 ### CLAM specific options
 parser.add_argument('--no_inst_cluster', action='store_true', default=False,
                      help='disable instance-level clustering')
@@ -193,33 +204,65 @@ elif args.task == 'task_2_tumor_subtyping':
     if args.model_type in ['clam_sb', 'clam_mb']:
         assert args.subtyping
 
-elif args.task == 'mnist_binary':
+elif args.task == 'mnist_fourbags':
     if args.data_root_dir is None:
-        raise ValueError('mnist_binary requires --data_root_dir pointing to the generated dataset directory')
-    args.n_classes = 2
-    csv_path = os.path.join(args.data_root_dir, 'mnist_binary.csv')
+        raise ValueError('mnist_fourbags requires --data_root_dir pointing to the generated dataset directory')
+    args.n_classes = 4
+    csv_path = os.path.join(args.data_root_dir, 'mnist_fourbags.csv')
     dataset = Generic_MIL_Dataset(csv_path=csv_path,
                             data_dir=os.path.join(args.data_root_dir, ''),
                             shuffle=False,
                             seed=args.seed,
                             print_info=True,
-                            label_dict={'negative': 0, 'positive': 1},
+                            label_dict={'none': 0, 'mostly_eight': 1, 'mostly_nine': 2, 'both': 3},
                             patient_strat=False,
                             ignore=[])
     if 'convis' in args.model_type or 'spvis' in args.model_type:
         dataset.load_from_h5(True)
 
-elif args.task == 'mnist_ternary':
+elif args.task == 'mnist_even_odd':
     if args.data_root_dir is None:
-        raise ValueError('mnist_ternary requires --data_root_dir pointing to the generated dataset directory')
-    args.n_classes = 3
-    csv_path = os.path.join(args.data_root_dir, 'mnist_ternary.csv')
+        raise ValueError('mnist_even_odd requires --data_root_dir pointing to the generated dataset directory')
+    args.n_classes = 2
+    csv_path = os.path.join(args.data_root_dir, 'mnist_even_odd.csv')
     dataset = Generic_MIL_Dataset(csv_path=csv_path,
                             data_dir=os.path.join(args.data_root_dir, ''),
                             shuffle=False,
                             seed=args.seed,
                             print_info=True,
-                            label_dict={'low_digit': 0, 'mid_digit': 1, 'high_digit': 2},
+                            label_dict={'odd_majority': 0, 'even_majority': 1},
+                            patient_strat=False,
+                            ignore=[])
+    if 'convis' in args.model_type or 'spvis' in args.model_type:
+        dataset.load_from_h5(True)
+
+elif args.task == 'mnist_adjacent_pairs':
+    if args.data_root_dir is None:
+        raise ValueError('mnist_adjacent_pairs requires --data_root_dir pointing to the generated dataset directory')
+    args.n_classes = 2
+    csv_path = os.path.join(args.data_root_dir, 'mnist_adjacent_pairs.csv')
+    dataset = Generic_MIL_Dataset(csv_path=csv_path,
+                            data_dir=os.path.join(args.data_root_dir, ''),
+                            shuffle=False,
+                            seed=args.seed,
+                            print_info=True,
+                            label_dict={'no_adjacent_pairs': 0, 'has_adjacent_pairs': 1},
+                            patient_strat=False,
+                            ignore=[])
+    if 'convis' in args.model_type or 'spvis' in args.model_type:
+        dataset.load_from_h5(True)
+
+elif args.task == 'mnist_fourbags_plus':
+    if args.data_root_dir is None:
+        raise ValueError('mnist_fourbags_plus requires --data_root_dir pointing to the generated dataset directory')
+    args.n_classes = 4
+    csv_path = os.path.join(args.data_root_dir, 'mnist_fourbags_plus.csv')
+    dataset = Generic_MIL_Dataset(csv_path=csv_path,
+                            data_dir=os.path.join(args.data_root_dir, ''),
+                            shuffle=False,
+                            seed=args.seed,
+                            print_info=True,
+                            label_dict={'none': 0, 'three_five': 1, 'one_only': 2, 'one_and_seven': 3},
                             patient_strat=False,
                             ignore=[])
     if 'convis' in args.model_type or 'spvis' in args.model_type:
@@ -236,14 +279,14 @@ if not os.path.isdir(args.results_dir):
     os.mkdir(args.results_dir)
 
 if args.split_dir is None:
-    if args.task in ['mnist_binary', 'mnist_ternary']:
+    if args.task in ['mnist_fourbags', 'mnist_even_odd', 'mnist_adjacent_pairs', 'mnist_fourbags_plus']:
         args.split_dir = os.path.join(args.data_root_dir, 'splits', args.task)
     else:
         args.split_dir = os.path.join('splits', args.task+'_{}'.format(int(args.label_frac*100)))
 else:
     if os.path.isabs(args.split_dir):
         args.split_dir = args.split_dir
-    elif args.task in ['mnist_binary', 'mnist_ternary']:
+    elif args.task in ['mnist_fourbags', 'mnist_even_odd', 'mnist_adjacent_pairs', 'mnist_fourbags_plus']:
         args.split_dir = os.path.join(args.data_root_dir, args.split_dir)
     else:
         args.split_dir = os.path.join('splits', args.split_dir)

--- a/processing_scripts/create_mnist_synthetic_dataset.py
+++ b/processing_scripts/create_mnist_synthetic_dataset.py
@@ -3,8 +3,10 @@
 The resulting directory mimics the structure expected by ``Generic_MIL_Dataset``:
 
 * ``h5_files`` contains one HDF5 file per synthetic "slide".
-* ``mnist_binary.csv`` stores slide-level labels for a binary task.
-* ``mnist_ternary.csv`` stores slide-level labels for a three-class task.
+* ``mnist_fourbags.csv`` stores slide-level labels for the Four-Bags task.
+* ``mnist_even_odd.csv`` stores slide-level labels for the even/odd majority task.
+* ``mnist_adjacent_pairs.csv`` stores slide-level labels for the adjacent-pairs task.
+* ``mnist_fourbags_plus.csv`` stores slide-level labels for the Four-Bags-Plus task.
 * ``splits/<task>/`` holds cross-validation splits aligned with ``main.py``.
 * ``images_shape.txt`` records the spatial canvas size for every slide.
 
@@ -17,7 +19,8 @@ Example
         --output-dir data/mnist_mil --num-slides 150 --k-folds 5
 
 The command above creates a dataset that can be consumed by the training
-entry-point with ``--task mnist_binary`` or ``--task mnist_ternary``.
+entry-point with the new tasks (``mnist_fourbags``, ``mnist_even_odd``,
+``mnist_adjacent_pairs``, and ``mnist_fourbags_plus``).
 """
 
 from __future__ import annotations
@@ -26,20 +29,44 @@ import argparse
 import math
 import os
 import random
+import shutil
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Dict, List, Sequence, Tuple
+from typing import Any, Dict, List, Sequence, Tuple
 
 import h5py
 import numpy as np
 import pandas as pd
+import torch
 from torchvision import datasets, transforms
 
+from processing_scripts.mnist_interpretability_tasks import (
+    EvidenceBundle,
+    TASK_METADATA_FNS,
+)
 
-GROUP_MAPPING = {
-    "low_digit": {0, 1, 2, 3},
-    "mid_digit": {4, 5, 6},
-    "high_digit": {7, 8, 9},
+
+TASK_LABEL_MAPS = {
+    "mnist_fourbags": {
+        0: "none",
+        1: "mostly_eight",
+        2: "mostly_nine",
+        3: "both",
+    },
+    "mnist_even_odd": {
+        0: "odd_majority",
+        1: "even_majority",
+    },
+    "mnist_adjacent_pairs": {
+        0: "no_adjacent_pairs",
+        1: "has_adjacent_pairs",
+    },
+    "mnist_fourbags_plus": {
+        0: "none",
+        1: "three_five",
+        2: "one_only",
+        3: "one_and_seven",
+    },
 }
 
 
@@ -49,8 +76,7 @@ class SlideExample:
 
     case_id: str
     slide_id: str
-    binary_label: str
-    ternary_label: str
+    labels: Dict[str, str]
 
 
 def parse_args() -> argparse.Namespace:
@@ -154,142 +180,30 @@ def make_grid_coords(num_instances: int, patch_size: int = 28) -> Tuple[np.ndarr
     return np.array(coords, dtype=np.int32), width, height
 
 
-def determine_labels(digits: Sequence[int]) -> Tuple[str, str]:
-    """Assign binary and ternary slide labels based on contained digits."""
-
-    binary_label = "positive" if any(digit >= 5 for digit in digits) else "negative"
-
-    counts = {
-        group: sum(1 for digit in digits if digit in members)
-        for group, members in GROUP_MAPPING.items()
-    }
-    # Resolve ties deterministically by sorting on (count, group_name).
-    ternary_label = max(counts.items(), key=lambda item: (item[1], item[0]))[0]
-    return binary_label, ternary_label
-
-
 def ensure_directory(path: str) -> None:
     os.makedirs(path, exist_ok=True)
 
 
-def majority_count(num_instances: int) -> int:
-    """Return the minimal count required to secure a strict majority."""
+def bundle_to_dict(
+    bundle: EvidenceBundle, numbers: Sequence[int], label: str
+) -> Dict[str, Any]:
+    """Convert an :class:`EvidenceBundle` to a serialisable dictionary."""
 
-    return max(1, num_instances // 2 + 1)
-
-
-def generate_digit_sequence(
-    rng: random.Random,
-    bag_size: int,
-    binary_label: str,
-    ternary_label: str,
-) -> Sequence[int]:
-    """Create a digit sequence that realizes the requested labels."""
-
-    if binary_label not in {"positive", "negative"}:
-        raise ValueError(f"Unknown binary label: {binary_label}")
-    if ternary_label not in GROUP_MAPPING:
-        raise ValueError(f"Unknown ternary label: {ternary_label}")
-
-    if binary_label == "negative" and ternary_label == "high_digit":
-        raise ValueError("Cannot construct a negative slide with a high_digit majority.")
-
-    digits: List[int] = []
-
-    if binary_label == "negative":
-        if ternary_label == "low_digit":
-            digits = [rng.choice(tuple(GROUP_MAPPING["low_digit"])) for _ in range(bag_size)]
-        else:  # ternary_label == "mid_digit"
-            # Ensure a strict majority of "4" digits while allowing some lower digits.
-            majority = majority_count(bag_size)
-            digits = [4] * majority
-            remaining = bag_size - majority
-            pool = tuple(GROUP_MAPPING["low_digit"])
-            digits.extend(rng.choice(pool) for _ in range(remaining))
-            rng.shuffle(digits)
-    else:  # binary positive
-        if ternary_label == "low_digit":
-            if bag_size == 1:
-                raise ValueError(
-                    "Cannot synthesize a positive slide with a single low_digit instance."
-                )
-            low_pool = tuple(GROUP_MAPPING["low_digit"])
-            digits = [rng.choice(low_pool) for _ in range(bag_size)]
-            # Inject a high-digit instance to flip the binary label while preserving majority.
-            digits[-1] = rng.choice(tuple(GROUP_MAPPING["high_digit"]))
-            rng.shuffle(digits)
-        elif ternary_label == "mid_digit":
-            mid_pool = tuple(GROUP_MAPPING["mid_digit"])
-            digits = [rng.choice(mid_pool) for _ in range(majority_count(bag_size))]
-            if not any(digit >= 5 for digit in digits):
-                digits[0] = rng.choice((5, 6))
-            remaining = bag_size - len(digits)
-            filler_pool = tuple(set(range(10)) - GROUP_MAPPING["mid_digit"])
-            digits.extend(rng.choice(filler_pool) for _ in range(remaining))
-            rng.shuffle(digits)
-        else:  # ternary_label == "high_digit"
-            high_pool = tuple(GROUP_MAPPING["high_digit"])
-            digits = [rng.choice(high_pool) for _ in range(majority_count(bag_size))]
-            remaining = bag_size - len(digits)
-            filler_pool = tuple(range(10))
-            digits.extend(rng.choice(filler_pool) for _ in range(remaining))
-            rng.shuffle(digits)
-
-    if len(digits) != bag_size:
-        raise ValueError("Digit synthesis failed to match the requested bag size.")
-
-    derived_binary, derived_ternary = determine_labels(digits)
-    if derived_binary != binary_label or derived_ternary != ternary_label:
-        raise ValueError(
-            "Generated digits do not satisfy requested labels: "
-            f"wanted ({binary_label}, {ternary_label}) but obtained "
-            f"({derived_binary}, {derived_ternary})."
-        )
-
-    return digits
-
-
-def plan_label_allocation(num_slides: int, rng: random.Random) -> List[Tuple[str, str]]:
-    """Return a balanced list of (binary_label, ternary_label) assignments."""
-
-    ternary_base = num_slides // 3
-    ternary_counts = {
-        "low_digit": ternary_base,
-        "mid_digit": ternary_base,
-        "high_digit": ternary_base,
+    evidence = {
+        cls: tensor.detach().cpu().numpy().tolist()
+        for cls, tensor in bundle.evidence.items()
     }
-    for idx, label in enumerate(("low_digit", "mid_digit", "high_digit")[: num_slides % 3]):
-        ternary_counts[label] += 1
-
-    positive_target = math.ceil(num_slides / 2)
-    negative_target = num_slides - positive_target
-
-    plans: List[Tuple[str, str]] = []
-
-    # High-digit slides must be positive.
-    for _ in range(ternary_counts["high_digit"]):
-        plans.append(("positive", "high_digit"))
-        positive_target -= 1
-
-    remaining_labels = (
-        ["low_digit"] * ternary_counts["low_digit"]
-        + ["mid_digit"] * ternary_counts["mid_digit"]
-    )
-
-    for label in remaining_labels:
-        if negative_target > 0:
-            plans.append(("negative", label))
-            negative_target -= 1
-        else:
-            plans.append(("positive", label))
-            positive_target -= 1
-
-    if positive_target != 0 or negative_target != 0:
-        raise ValueError("Failed to allocate label plan with the requested balance.")
-
-    rng.shuffle(plans)
-
-    return plans
+    if bundle.instance_labels is not None:
+        instance_labels = bundle.instance_labels.detach().cpu().numpy().tolist()
+    else:
+        instance_labels = None
+    return {
+        "numbers": list(numbers),
+        "target": bundle.target,
+        "label": label,
+        "evidence": evidence,
+        "instance_labels": instance_labels,
+    }
 
 
 def write_h5(features: np.ndarray, coords: np.ndarray, destination: str) -> None:
@@ -421,81 +335,108 @@ def main() -> None:
         for digit in range(10)
     }
 
-    rng = random.Random(args.seed)
     examples: List[SlideExample] = []
+    evidence_root = os.path.join(args.output_dir, "evidence")
+    if os.path.exists(evidence_root):
+        shutil.rmtree(evidence_root)
 
-    label_plan = plan_label_allocation(args.num_slides, rng)
-
-    for slide_index, (binary_label, ternary_label) in enumerate(label_plan):
-        for _ in range(128):
+    attempt = 0
+    slides: List[Dict[str, Any]] = []
+    class_counts: Dict[str, Dict[str, int]] = {}
+    while attempt < 32:
+        rng = random.Random(args.seed + attempt)
+        slides = []
+        class_counts = {
+            task: {label: 0 for label in label_map.values()}
+            for task, label_map in TASK_LABEL_MAPS.items()
+        }
+        for _ in range(args.num_slides):
             bag_size = rng.randint(args.min_patches, args.max_patches)
-            try:
-                digit_sequence = generate_digit_sequence(
-                    rng, bag_size, binary_label, ternary_label
-                )
-            except ValueError:
-                continue
-
+            digit_sequence = [rng.randrange(10) for _ in range(bag_size)]
             features, digit_labels = sample_slide_contents(
                 rng, digit_sequence, images, digit_to_indices
             )
             coords, width, height = make_grid_coords(len(digit_labels))
-            break
-        else:
-            raise RuntimeError(
-                "Failed to synthesize a slide matching the requested label combination. "
-                "Consider relaxing the patch-count bounds."
+            numbers_tensor = torch.tensor(digit_labels, dtype=torch.long)
+
+            task_labels: Dict[str, str] = {}
+            bundles: Dict[str, EvidenceBundle] = {}
+            for task_name, metadata_fn in TASK_METADATA_FNS.items():
+                bundle = metadata_fn(numbers_tensor)
+                label_map = TASK_LABEL_MAPS[task_name]
+                label = label_map.get(bundle.target)
+                if label is None:
+                    raise KeyError(
+                        f"Task {task_name} does not provide a label mapping for target {bundle.target}."
+                    )
+                task_labels[task_name] = label
+                bundles[task_name] = bundle
+                class_counts[task_name][label] += 1
+
+            slides.append(
+                {
+                    "features": features,
+                    "coords": coords,
+                    "width": width,
+                    "height": height,
+                    "numbers": digit_labels,
+                    "labels": task_labels,
+                    "bundles": bundles,
+                }
             )
 
+        if all(all(count > 0 for count in counts.values()) for counts in class_counts.values()):
+            break
+        attempt += 1
+    else:
+        raise RuntimeError(
+            "Failed to synthesise a dataset containing all classes for every task. "
+            "Consider increasing --num-slides or widening the patch-count range."
+        )
+
+    for slide_index, slide in enumerate(slides):
         slide_id = f"slide_{slide_index:04d}"
         case_id = f"case_{slide_index // args.slides_per_case:04d}"
 
-        write_h5(features, coords, os.path.join(h5_root, f"{slide_id}.h5"))
-        save_shape_entry(shape_file, slide_id, width, height)
+        write_h5(slide["features"], slide["coords"], os.path.join(h5_root, f"{slide_id}.h5"))
+        save_shape_entry(shape_file, slide_id, slide["width"], slide["height"])
 
         examples.append(
             SlideExample(
                 case_id=case_id,
                 slide_id=slide_id,
-                binary_label=binary_label,
-                ternary_label=ternary_label,
+                labels=slide["labels"],
             )
         )
 
-    binary_df = pd.DataFrame(
-        {
-            "case_id": [example.case_id for example in examples],
-            "slide_id": [example.slide_id for example in examples],
-            "label": [example.binary_label for example in examples],
-        }
-    )
-    binary_df.to_csv(os.path.join(args.output_dir, "mnist_binary.csv"), index=False)
+        for task_name, bundle in slide["bundles"].items():
+            task_dir = os.path.join(evidence_root, task_name)
+            ensure_directory(task_dir)
+            payload = bundle_to_dict(
+                bundle,
+                slide["numbers"],
+                slide["labels"][task_name],
+            )
+            torch.save(payload, os.path.join(task_dir, f"{slide_id}.pt"))
 
-    ternary_df = pd.DataFrame(
-        {
-            "case_id": [example.case_id for example in examples],
-            "slide_id": [example.slide_id for example in examples],
-            "label": [example.ternary_label for example in examples],
-        }
-    )
-    ternary_df.to_csv(os.path.join(args.output_dir, "mnist_ternary.csv"), index=False)
+    for task_name in TASK_METADATA_FNS.keys():
+        df = pd.DataFrame(
+            {
+                "case_id": [example.case_id for example in examples],
+                "slide_id": [example.slide_id for example in examples],
+                "label": [example.labels[task_name] for example in examples],
+            }
+        )
+        df.to_csv(os.path.join(args.output_dir, f"{task_name}.csv"), index=False)
 
-    save_splits(
-        examples,
-        label_accessor=lambda example: example.binary_label,
-        task_name="mnist_binary",
-        output_dir=args.output_dir,
-        k_folds=args.k_folds,
-        rng=rng,
-    )
-    save_splits(
-        examples,
-        label_accessor=lambda example: example.ternary_label,
-        task_name="mnist_ternary",
-        output_dir=args.output_dir,
-        k_folds=args.k_folds,
-        rng=rng,
-    )
+        save_splits(
+            examples,
+            label_accessor=lambda example, task=task_name: example.labels[task],
+            task_name=task_name,
+            output_dir=args.output_dir,
+            k_folds=args.k_folds,
+            rng=random.Random(args.seed),
+        )
 
     print(f"Synthetic dataset written to {args.output_dir}")
 

--- a/processing_scripts/mnist_interpretability_tasks.py
+++ b/processing_scripts/mnist_interpretability_tasks.py
@@ -1,0 +1,147 @@
+"""Helpers defining synthetic MNIST MIL tasks used for interpretability tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional
+
+import torch
+
+
+@dataclass(frozen=True)
+class EvidenceBundle:
+    """Container describing the metadata attached to a MIL bag."""
+
+    target: int
+    evidence: Mapping[int, torch.Tensor]
+    instance_labels: Optional[torch.Tensor]
+
+
+def _count_digits(numbers: torch.Tensor, num_numbers: int) -> torch.Tensor:
+    return torch.bincount(numbers, minlength=num_numbers)
+
+
+def _positions(numbers: torch.Tensor, value: int) -> torch.Tensor:
+    return (numbers == value).to(torch.float32)
+
+
+def fourbags_metadata(
+    numbers: torch.Tensor, num_numbers: int = 10, threshold: int = 1
+) -> EvidenceBundle:
+    number_count = _count_digits(numbers, num_numbers)
+    c1_number, c2_number = 8, 9
+    if number_count[c1_number] >= threshold > number_count[c2_number]:
+        target = 1
+    elif number_count[c2_number] >= threshold > number_count[c1_number]:
+        target = 2
+    elif number_count[c1_number] >= threshold and number_count[c2_number] >= threshold:
+        target = 3
+    else:
+        target = 0
+    num_positions = {
+        c1_number: _positions(numbers, c1_number),
+        c2_number: _positions(numbers, c2_number),
+    }
+    evidence = {
+        0: -num_positions[c1_number] - num_positions[c2_number],
+        1: num_positions[c1_number] - num_positions[c2_number],
+        2: -num_positions[c1_number] + num_positions[c2_number],
+        3: num_positions[c1_number] + num_positions[c2_number],
+    }
+    return EvidenceBundle(target=target, evidence=evidence, instance_labels=None)
+
+
+def evenodd_metadata(numbers: torch.Tensor) -> EvidenceBundle:
+    even_numbers = torch.tensor([0, 2, 4, 6, 8], device=numbers.device)
+    odd_numbers = torch.tensor([1, 3, 5, 7, 9], device=numbers.device)
+    number_count = _count_digits(numbers, 10)
+    if number_count[even_numbers].sum() > number_count[odd_numbers].sum():
+        target = 1
+    else:
+        target = 0
+    pos_evidence = torch.isin(numbers, even_numbers).to(torch.float32)
+    neg_evidence = torch.isin(numbers, odd_numbers).to(torch.float32)
+    evidence = {0: neg_evidence - pos_evidence, 1: pos_evidence - neg_evidence}
+    instance_labels = torch.zeros_like(numbers)
+    instance_labels[torch.isin(numbers, even_numbers)] = 1
+    return EvidenceBundle(target=target, evidence=evidence, instance_labels=instance_labels)
+
+
+def adjacentpairs_metadata(
+    numbers: torch.Tensor, num_numbers: int = 10, threshold: int = 1
+) -> EvidenceBundle:
+    number_count = _count_digits(numbers, num_numbers)
+    evidence_thr = 5
+    digits_with_threshold = (number_count >= threshold).nonzero().squeeze().tolist()
+    pos_tuples = []
+    if isinstance(digits_with_threshold, list) and len(digits_with_threshold) > 1:
+        digits_with_threshold = [
+            digit for digit in digits_with_threshold if digit < evidence_thr
+        ]
+        for idx, num_0 in enumerate(digits_with_threshold):
+            num_1 = digits_with_threshold[(idx + 1) % len(digits_with_threshold)]
+            if (num_0 + 1) == num_1:
+                pos_tuples.append([num_0, num_1])
+    if len(pos_tuples) >= threshold:
+        target = 1
+    else:
+        target = 0
+    if pos_tuples:
+        flat = torch.tensor(pos_tuples, device=numbers.device).flatten()
+        pos_evidence = torch.isin(numbers, flat).to(torch.float32)
+    else:
+        pos_evidence = torch.zeros_like(numbers, dtype=torch.float32)
+    evidence = {0: -pos_evidence, 1: pos_evidence}
+    return EvidenceBundle(target=target, evidence=evidence, instance_labels=None)
+
+
+def fourbagsplus_metadata(numbers: torch.Tensor) -> EvidenceBundle:
+    bag_numbers = numbers
+    has_3 = (bag_numbers == 3).any().item()
+    has_5 = (bag_numbers == 5).any().item()
+    has_1 = (bag_numbers == 1).any().item()
+    has_7 = (bag_numbers == 7).any().item()
+    if has_3 and has_5:
+        bag_label = 1
+    elif has_1 and not has_7:
+        bag_label = 2
+    elif has_1 and has_7:
+        bag_label = 3
+    else:
+        bag_label = 0
+    instance_labels = torch.zeros_like(bag_numbers)
+    instance_labels[(bag_numbers == 3) | (bag_numbers == 5)] = 1
+    instance_labels[bag_numbers == 7] = 3
+    if has_7:
+        instance_labels[bag_numbers == 1] = 3
+    else:
+        instance_labels[bag_numbers == 1] = 1
+    evidence = {
+        0: -(
+            (bag_numbers == 3).to(torch.float32)
+            + (bag_numbers == 5).to(torch.float32)
+            + (bag_numbers == 1).to(torch.float32)
+            + (bag_numbers == 7).to(torch.float32)
+        ),
+        1: (bag_numbers == 3).to(torch.float32)
+        + (bag_numbers == 5).to(torch.float32)
+        - (bag_numbers == 1).to(torch.float32)
+        - (bag_numbers == 7).to(torch.float32),
+        2: (bag_numbers == 1).to(torch.float32)
+        - (bag_numbers == 7).to(torch.float32)
+        - (bag_numbers == 3).to(torch.float32)
+        - (bag_numbers == 5).to(torch.float32),
+        3: (bag_numbers == 1).to(torch.float32)
+        + (bag_numbers == 7).to(torch.float32)
+        - (bag_numbers == 3).to(torch.float32)
+        - (bag_numbers == 5).to(torch.float32),
+    }
+    return EvidenceBundle(target=bag_label, evidence=evidence, instance_labels=instance_labels)
+
+
+TASK_METADATA_FNS: Dict[str, callable] = {
+    "mnist_fourbags": fourbags_metadata,
+    "mnist_even_odd": evenodd_metadata,
+    "mnist_adjacent_pairs": adjacentpairs_metadata,
+    "mnist_fourbags_plus": fourbagsplus_metadata,
+}

--- a/vis_utils/mnist_attention_heatmap.py
+++ b/vis_utils/mnist_attention_heatmap.py
@@ -32,8 +32,10 @@ from vis_utils.visualize_mnist_slide import (
 
 
 LABEL_DICTS: Dict[str, Dict[str, int]] = {
-    'mnist_binary': {'negative': 0, 'positive': 1},
-    'mnist_ternary': {'low_digit': 0, 'mid_digit': 1, 'high_digit': 2},
+    'mnist_fourbags': {'none': 0, 'mostly_eight': 1, 'mostly_nine': 2, 'both': 3},
+    'mnist_even_odd': {'odd_majority': 0, 'even_majority': 1},
+    'mnist_adjacent_pairs': {'no_adjacent_pairs': 0, 'has_adjacent_pairs': 1},
+    'mnist_fourbags_plus': {'none': 0, 'three_five': 1, 'one_only': 2, 'one_and_seven': 3},
 }
 
 
@@ -43,7 +45,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument('--dataset-root', type=Path, required=True)
     parser.add_argument('--checkpoint', type=Path, required=True)
-    parser.add_argument('--task', choices=tuple(LABEL_DICTS.keys()), default='mnist_binary')
+    parser.add_argument('--task', choices=tuple(LABEL_DICTS.keys()), default='mnist_fourbags')
     parser.add_argument('--model-type', choices=['bmil-vis', 'bmil-enc', 'bmil-spvis'], default='bmil-vis')
     parser.add_argument('--model-size', choices=['small', 'big'], default='small')
     parser.add_argument('--drop-out', action='store_true', help='Set when the checkpoint was trained with dropout enabled.')

--- a/vis_utils/visualize_mnist_slide.py
+++ b/vis_utils/visualize_mnist_slide.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import argparse
 import os
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 import h5py
 import matplotlib.pyplot as plt
@@ -32,13 +32,26 @@ import pandas as pd
 
 PATCH_PIXELS = 28
 
+TASK_TO_CSV: Dict[str, str] = {
+    "mnist_fourbags": "mnist_fourbags.csv",
+    "mnist_even_odd": "mnist_even_odd.csv",
+    "mnist_adjacent_pairs": "mnist_adjacent_pairs.csv",
+    "mnist_fourbags_plus": "mnist_fourbags_plus.csv",
+}
+
+TASK_DISPLAY_NAMES: Dict[str, str] = {
+    "mnist_fourbags": "fourbags",
+    "mnist_even_odd": "even-odd",
+    "mnist_adjacent_pairs": "adjacent",
+    "mnist_fourbags_plus": "fourbags+",
+}
+
 
 @dataclass(frozen=True)
 class SlideLabels:
-    """Container for the binary and ternary labels tied to a slide."""
+    """Container for the task-specific labels tied to a slide."""
 
-    binary: Optional[str]
-    ternary: Optional[str]
+    values: Dict[str, Optional[str]]
 
 
 def parse_args() -> argparse.Namespace:
@@ -109,10 +122,10 @@ def load_labels(dataset_root: str, slide_id: str) -> SlideLabels:
         matches = frame.loc[frame["slide_id"] == slide_id, "label"]
         return matches.iloc[0] if not matches.empty else None
 
-    return SlideLabels(
-        binary=_read_label("mnist_binary.csv"),
-        ternary=_read_label("mnist_ternary.csv"),
-    )
+    values: Dict[str, Optional[str]] = {}
+    for task, csv_name in TASK_TO_CSV.items():
+        values[task] = _read_label(csv_name)
+    return SlideLabels(values=values)
 
 
 def reconstruct_canvas(features: np.ndarray, coords: np.ndarray) -> np.ndarray:
@@ -128,10 +141,11 @@ def reconstruct_canvas(features: np.ndarray, coords: np.ndarray) -> np.ndarray:
 
 def format_title(slide_id: str, labels: SlideLabels) -> str:
     parts = [slide_id]
-    if labels.binary is not None:
-        parts.append(f"binary: {labels.binary}")
-    if labels.ternary is not None:
-        parts.append(f"ternary: {labels.ternary}")
+    for task in sorted(labels.values.keys()):
+        value = labels.values[task]
+        if value is not None:
+            display = TASK_DISPLAY_NAMES.get(task, task)
+            parts.append(f"{display}: {value}")
     return " | ".join(parts)
 
 


### PR DESCRIPTION
## Summary
- replace the legacy binary/ternary MNIST tasks with four interpretability-oriented tasks (Four Bags, Even/Odd, Adjacent Pairs, Four Bags Plus)
- extend the synthetic dataset generator to emit labels, splits, and evidence files for every task using reusable metadata helpers
- refresh training, evaluation, and visualisation utilities plus documentation to support the new task names and label sets

## Testing
- python -m compileall processing_scripts examples vis_utils main.py eval.py

------
https://chatgpt.com/codex/tasks/task_e_68e5588bb96c8324b7d8f194e04d5830