### PR TITLE
Add F1 score reporting to evaluation and training pipelines

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -193,6 +193,7 @@ if __name__ == "__main__":
     all_results = []
     all_auc = []
     all_acc = []
+    all_f1 = []
     for ckpt_idx in range(len(ckpt_paths)):
         if datasets_id[args.split] < 0:
             split_dataset = dataset
@@ -202,17 +203,18 @@ if __name__ == "__main__":
             split_dataset = datasets[datasets_id[args.split]]
 
         # previous evaluation function
-        model, patient_results, test_error, auc, df  = eval(split_dataset, args, ckpt_paths[ckpt_idx])
+        model, patient_results, test_error, auc, f1, df  = eval(split_dataset, args, ckpt_paths[ckpt_idx])
         all_results.append(all_results)
         all_auc.append(auc)
         all_acc.append(1-test_error)
+        all_f1.append(f1)
         df.to_csv(os.path.join(args.save_dir, 'fold_{}.csv'.format(folds[ckpt_idx])), index=False)
 
         # for retriving the uncertainties
         
 
 
-    final_df = pd.DataFrame({'folds': folds, 'test_auc': all_auc, 'test_acc': all_acc})
+    final_df = pd.DataFrame({'folds': folds, 'test_auc': all_auc, 'test_acc': all_acc, 'test_f1': all_f1})
     if len(folds) != args.k:
         save_name = 'summary_partial_{}_{}.csv'.format(folds[0], folds[-1])
     else:

--- a/main.py
+++ b/main.py
@@ -49,6 +49,8 @@ def main(args):
     all_val_acc = []
     all_test_ece_loss = []
     all_val_ece_loss = []
+    all_test_f1 = []
+    all_val_f1 = []
     folds = np.arange(start, end)
     for i in folds:
         seed_torch(args.seed)
@@ -58,13 +60,15 @@ def main(args):
         print('------------------use h5? {}--------------------'.format(train_dataset.use_h5))
 
         datasets = (train_dataset, val_dataset, test_dataset)
-        results, test_auc, val_auc, test_acc, val_acc, test_ece_loss, val_ece_loss  = train(datasets, i, args)
+        results, test_auc, val_auc, test_acc, val_acc, test_ece_loss, val_ece_loss, test_f1, val_f1  = train(datasets, i, args)
         all_test_auc.append(test_auc)
         all_val_auc.append(val_auc)
         all_test_acc.append(test_acc)
         all_val_acc.append(val_acc)
         all_test_ece_loss.append(test_ece_loss)
         all_val_ece_loss.append(val_ece_loss)
+        all_test_f1.append(test_f1)
+        all_val_f1.append(val_f1)
         #write results to pkl
         filename = os.path.join(args.results_dir, 'split_{}_results.pkl'.format(i))
         save_pkl(filename, results)
@@ -72,7 +76,9 @@ def main(args):
     final_df = pd.DataFrame({'folds': folds, 'test_auc': all_test_auc,
                              'val_auc': all_val_auc, 'test_acc': all_test_acc, 'val_acc': all_val_acc,
                              'test_ece_loss': all_test_ece_loss,
-                             'val_ece_loss': all_val_ece_loss})
+                             'val_ece_loss': all_val_ece_loss,
+                             'test_f1': all_test_f1,
+                             'val_f1': all_val_f1})
 
     if len(folds) != args.k:
         save_name = 'summary_partial_{}_{}.csv'.format(start, end)


### PR DESCRIPTION
## Summary
- add macro/binary F1 score computation to evaluation utilities and surface the metric in console output and saved summaries
- propagate F1 reporting through the training loop, TensorBoard logging, and experiment summaries for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e68c7a46ec8324944307a63f46dad0